### PR TITLE
OpenSSL Docker Image Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN apt-get update && \
 COPY ./docker-entrypoint.sh /
 
 # create the openssl directory volumes
-VOLUME ["/etc/ssl", "/usr/share/ca-certificates", "/usr/local/share/ca-certificates", "/etc/grid-security"]
+VOLUME ["/etc/ssl/private"]
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Updates openssl container to only deal with private certificates and a single volume.

Backup/restore scripts are also updated.